### PR TITLE
Fix URL schema of Docker Hub "Tags" deep link

### DIFF
--- a/generate-index.sh
+++ b/generate-index.sh
@@ -136,6 +136,6 @@ for version in "${suites[@]}"; do
 	done
 
 	echo
-	echo "- Docker Hub: [\`debian:$uniqueTag\`](https://hub.docker.com/_/debian?tab=tags&name=$uniqueTag)"
+	echo "- Docker Hub: [\`debian:$uniqueTag\`](https://hub.docker.com/_/debian/tags?name=$uniqueTag)"
 	echo "- Build Command: \`./examples/debian.sh --arch <dpkg-arch> out/ '$version' '@${sharedMeta[debuerreotype-epoch]}'\`"
 done


### PR DESCRIPTION
Just a quick fix to get the deep links to the "Tags" page working again.